### PR TITLE
Notificacion personalizada para reiniciar contraseña agregada

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,8 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
+use App\Notifications\MailResetPasswordNotification as ResetPasswordNotification;
+
 
 class User extends Authenticatable
 
@@ -73,6 +75,12 @@ class User extends Authenticatable
     public function getUserOrden()
     {
         return $this->hasMany('App\Models\OrdenPurchases', 'iduser');
+    }
+
+    public function sendPasswordResetNotification($token)
+    {
+        // Your your own implementation.
+        $this->notify(new ResetPasswordNotification($token));
     }
 
 }

--- a/app/Notifications/MailResetPasswordNotification.php
+++ b/app/Notifications/MailResetPasswordNotification.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MailResetPasswordNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($token)
+    {
+        //
+        $this->token = $token;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->greeting('¡Hola!')
+            ->subject('Reinicio de contraseña')
+            ->line('Esta recibiendo este correo porque se ha pedido reiniciar la contraseña desde su cuenta.')
+            ->action('Reiniciar contrasesña', url('password/reset', $this->token))
+            ->line('Si usted no pidio reiniciar la contraseña, no necesita realizar ninguna acción.');
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}


### PR DESCRIPTION
El servicio de reiniciar contraseña estaba por default al generar el auth en laravel, esta notificacion personalizada permite cambiar/personalizar el texto del mail y la vista si se quiere que va a ser enviado al correo del usuario para reiniciar la contraseña.